### PR TITLE
Fix post-3.3 collections.abc warning

### DIFF
--- a/pystmark.py
+++ b/pystmark.py
@@ -15,7 +15,10 @@
         Wrapper class for Message attachments and headers?
 """
 
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from base64 import b64encode
 import requests
 import mimetypes


### PR DESCRIPTION
The warning in question:

```
pystmark.py:18: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```
