### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ except UnauthorizedError:
 # Check for errors in each message when sending batch emails:
 for m in response.messages:
     if m.error_code > 0:
-        raise PystmarkError(m.message)
+        print m.message
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ from pystmark import (
     send_with_template,
     send_batch,
     send_batch_with_templates,
-    UnauthorizedError,
-    PystmarkError
+    UnauthorizedError
 )
 
 API_KEY = 'my_api_key'

--- a/pystmark.py
+++ b/pystmark.py
@@ -152,7 +152,7 @@ def send_batch_with_templates(messages,
     :param test: Use the Postmark Test API. Defaults to `False`.
     :param request_args: Keyword arguments to pass to
         :func:`requests.request`.
-    :rtype: :class:`SendResponse`
+    :rtype: :class:`BatchSendResponse`
     """
     return _default_pyst_batch_template_sender.send(messages=messages,
                                                     api_key=api_key,


### PR DESCRIPTION
Minor doc improvement; don't suggest raising on a single faulty email address in README.
Errors like this for a single recipient would halt execution which is probably not desirable:

```
Error parsing 'To': Illegal email domain 'åäö.se' in address 'test@åäö.se'.
```

Also, doc fix for wrong return type in `send_batch_with_templates`.